### PR TITLE
Compile nim code properly

### DIFF
--- a/nim/run.bat
+++ b/nim/run.bat
@@ -1,1 +1,1 @@
-nim c -r RayTracer.nim
+nim c d:release --opt:speed --passL:-s -r RayTracer.nim


### PR DESCRIPTION
In `run.bat`, the code is compiled for debug, not for release.

In my computer, the debug version runs in 3970.045161ms, and the release version runs in 326.847238ms (there is also the `-d:danger` version, that removes every runtime check, is runs in 280.891409ms)