### PR TITLE
avoid measuring compilation time

### DIFF
--- a/julia/RayTracer.jl
+++ b/julia/RayTracer.jl
@@ -353,6 +353,8 @@ function Render(scene::Scene)
     return image
 end
 
+scene = Scene()
+image = Render(scene)
 @time begin
     scene = Scene()
     image = Render(scene)


### PR DESCRIPTION
In Julia, the code is compiled in first call to every function, thus compilation time was being measured here, and might be significant. Running the two commands before the time-measure is more appropriate (or, alternatively, using `@btime` from `BenchmarkTools`, except I don't know if you are willing to include other packages not from the base language).