### PR TITLE
avoid measuring compilation time

### DIFF
--- a/julia/RayTracer.jl
+++ b/julia/RayTracer.jl
@@ -351,7 +351,9 @@ function Render(scene::Scene)
     end
     return image
 end
-
+                                                                                                        
+scene = Scene()
+image = Render(scene)
 @time begin
     scene = Scene()
     image = Render(scene)


### PR DESCRIPTION
Run once before timing, such that compilation time is not measured (regression introduced in a recent commit). Would be nice to run the benchmark with this and update the timing in the table.