### PR TITLE
Add WebAssembly test with a little bit macro changes in RayTracer.c.

### DIFF
--- a/c/RayTracer.c
+++ b/c/RayTracer.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <time.h>
 #include <stdint.h>
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 const double FarAway = 1000000.0;
 
@@ -577,6 +580,18 @@ int main()
 
     printf("Completed in %d ms\n", time_ms);
     SaveRGBBitmap(&bitmapData[0], width, height, 32, "c-raytracer.bmp");
+#if __EMSCRIPTEN__
+    EM_ASM(
+        const stream = FS.open("c-raytracer.bmp", "r");
+        const blob = new Blob([stream.node.contents], { type: "image/bmp" });
+        const a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = "webassembly-raytracer.bmp";
+        a.click();
+        URL.revokeObjectURL(a.href);
+        a.remove();
+    );
+#endif
 
     ReleaseScene(&scene);
     free(bitmapData);

--- a/webassembly/build.o1.ps1
+++ b/webassembly/build.o1.ps1
@@ -1,0 +1,2 @@
+emsdk_env.ps1
+emcc ../c/RayTracer.c -O1 -s WASM=1 -s SINGLE_FILE=1 -o RayTracer.html

--- a/webassembly/build.ps1
+++ b/webassembly/build.ps1
@@ -1,0 +1,2 @@
+emsdk_env.ps1
+emcc ../c/RayTracer.c -O3 -s WASM=1 -s SINGLE_FILE=1 -o RayTracer.html


### PR DESCRIPTION
In my computer, c version is completed in 31ms, and its webassembly version costs 38ms with -O3 and 43ms with -O1. Expect you to test and update the running time on your computer. By the way, the javascript version needs 140ms (node 14).

ps: 
1. Install Emscripten
2. Add emsdk folder to your system env variables
3. Run the build.ps1 on PowerShell
4. Open the output html file on your Chrome